### PR TITLE
修复了Agent运行时间过长可能导致人物漂移的bug

### DIFF
--- a/CodeSurvivorServer.py
+++ b/CodeSurvivorServer.py
@@ -638,7 +638,7 @@ def main(agents_folder, map_file):
 						print(f'{player.agent.name}函数超时了')
 
 			game_map.update()
-			last_update_time = now
+			last_update_time = pygame.time.get_ticks()
 			tick_count += 1
 
 		players.update()


### PR DESCRIPTION
last_update_time错误地使用了Agent运行前的时间，导致有时人物尚未移动完成就开始下一轮移动